### PR TITLE
Fixed "Could not find a part of the path" error

### DIFF
--- a/Game/ForTesting/Tests.cs
+++ b/Game/ForTesting/Tests.cs
@@ -7,7 +7,7 @@ namespace Game.ForTesting
     {
         public void Test1()
         {
-            string sourcePath = @"d:\CSharp Game Project\Game\Sprites\DefaultPose.txt";
+            string sourcePath = @"..\..\..\..\Sprites\DefaultPose(For testing).txt";
 
             try
             {

--- a/Game/Screen.cs
+++ b/Game/Screen.cs
@@ -44,7 +44,7 @@ namespace Game
         }
         public void Idle()        // Prints the standard position of the characters
         {
-            string sourcePath = @"d:\CSharp Game Project\Game\Sprites\Idle.txt";
+            string sourcePath = @"..\..\..\..\Sprites\Idle.txt"; //Might not work when exporting the game -> different folder structure
 
             try
             {


### PR DESCRIPTION
Fixed the Issue #1 by making the path relative.

For later use, i recommend the usage of a different way to store the texts, e.g. a resource file or as a string.